### PR TITLE
Added use_base_currency option for Hosted payment method

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -419,6 +419,16 @@ class Config implements \Magento\Payment\Model\Method\ConfigInterface
     }
 
     /**
+     * Determines whether to take payment in the order base currency or not
+     *
+     * @return bool
+     */
+    public function getUseBaseCurrency()
+    {
+        return $this->isChecked($this->_methodCode, 'use_base_currency');
+    }
+
+    /**
      * Gets Log Level
      *
      * @return int

--- a/Model/Traits/Transactions.php
+++ b/Model/Traits/Transactions.php
@@ -661,9 +661,11 @@ trait Transactions
         $billingAddress = $order->getBillingAddress();
         $config = $this->getConfigHelper();
         $orderId = $order->getRealOrderId();
+        $total = $config->getUseBaseCurrency() ? $order->getBaseTotalDue() : $order->getTotalDue();
+        $currency = $config->getUseBaseCurrency() ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
         return [
-            'Amount'                    => $order->getTotalDue() * 100,
-            'CurrencyCode'              => DataBuilder::getCurrencyIsoCode($order->getOrderCurrencyCode()),
+            'Amount'                    => $total * 100,
+            'CurrencyCode'              => DataBuilder::getCurrencyIsoCode($currency),
             'OrderID'                   => $orderId,
             'TransactionType'           => $config->getTransactionType(),
             'TransactionDateTime'       => date('Y-m-d H:i:s P'),

--- a/etc/adminhtml/system/paymentsense_hosted.xml
+++ b/etc/adminhtml/system/paymentsense_hosted.xml
@@ -155,6 +155,12 @@ GNU General Public License for more details.
             </depends>
             <can_be_empty>0</can_be_empty>
         </field>
+        <field id="use_base_currency" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Use website base currency?</label>
+            <tooltip><![CDATA[Take the payment in the order's base currency? (Magento displays this on the checkout when the user has selected an alternative currency)]]></tooltip>
+            <config_path>payment/paymentsense_hosted/use_base_currency</config_path>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
 
         <field id="email_address_editable" translate="label" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Email Address can be altered on payment form:</label>

--- a/etc/adminhtml/system/paymentsense_hosted.xml
+++ b/etc/adminhtml/system/paymentsense_hosted.xml
@@ -155,7 +155,7 @@ GNU General Public License for more details.
             </depends>
             <can_be_empty>0</can_be_empty>
         </field>
-        <field id="use_base_currency" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="use_base_currency" translate="label" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Use website base currency?</label>
             <tooltip><![CDATA[Take the payment in the order's base currency? (Magento displays this on the checkout when the user has selected an alternative currency)]]></tooltip>
             <config_path>payment/paymentsense_hosted/use_base_currency</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -36,6 +36,7 @@ GNU General Public License for more details.
                 <country_mandatory>0</country_mandatory>
                 <allowspecific>0</allowspecific>
                 <allow_specific_currency>0</allow_specific_currency>
+                <use_base_currency>0</use_base_currency>
                 <log_level>1</log_level>
                 <port_4430_not_open>0</port_4430_not_open>
                 <group>paymentsense</group>


### PR DESCRIPTION
Hi, we wanted to be able to run a Magento store with multiple currencies, but take payment in the base currency for situations where the merchant has only one currency account.

When using an alternative currency, Magento displays "You will be charged x.xx" in the checkout totals block, giving the base currency amount, but the underlying core code seems to request payment from the payment method class in the alternative currency (tested on Magento 2.3.1)

Magento config for currency states that transactions will be made in the base currency of the store. This pull request adds a new config option to enable that behaviour, but only for the Hosted method - if there's enough interest, we can add it for the other methods.

(Zendesk ticket #1752579 )