### PR TITLE
Switch checkout layout from 1column to checkout 

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 @copyright   2020 Paymentsense Ltd.
 @license     https://www.gnu.org/licenses/gpl-3.0.html
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>


### PR DESCRIPTION
Switch checkout layout from 1column to checkout to avoid loading additional containers/blocks.